### PR TITLE
Fix convertion of primitive types

### DIFF
--- a/src/parser/data.ts
+++ b/src/parser/data.ts
@@ -171,7 +171,7 @@ class DataParser {
 			}
 
 			// If not, it's a simple value
-			output.push(`const ${identifier} = ref('${property.value.value}');`);
+			output.push(`const ${identifier} = ref(${property.value.raw});`);
 			this.imports.ref = true;
 			this.identifiers[identifier] = 'ref';
 		});


### PR DESCRIPTION
This PR fixes the conversion of all the primitive types to string, 

instead of converting 

```js
export default {
  data() {
    return {
      loading: true,
      imageWidth: 0,
      imageHeight: null,
      showViewer: "hello"
    };
  }
}
```
to 

```js
const loading = ref('true');
const imageWidth = ref('0');
const imageHeight = ref('null');
const showViewer = ref('hello');
```

it converts to 

```js
const loading = ref(true);
const imageWidth = ref(0);
const imageHeight = ref(null);
const showViewer = ref("hello");
`

